### PR TITLE
Updated the RPC nuget package version

### DIFF
--- a/src/src.csproj
+++ b/src/src.csproj
@@ -30,8 +30,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="6.2.0" />
-    <PackageReference Include="PipServices3.Commons" Version="3.0.6" />
+    <PackageReference Include="PipServices3.Commons" Version="3.0.11" />
     <PackageReference Include="PipServices3.Components" Version="3.0.4" />
-    <PackageReference Include="PipServices3.Rpc" Version="3.0.4" />
+    <PackageReference Include="PipServices3.Rpc" Version="3.0.8" />
   </ItemGroup>
 </Project>

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -19,9 +19,12 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the RPC nuget package version used, to allow for a HTTPS connection with no security credentials, when using the "internal_network" flag