### PR TITLE
Elastic Search Index Pattern is configurable from the config.yml file. 

### DIFF
--- a/src/Log/ElasticSearchLogger.cs
+++ b/src/Log/ElasticSearchLogger.cs
@@ -36,8 +36,9 @@ namespace PipServices3.ElasticSearch.Log
     /// 
     /// options:
     /// - interval:        interval in milliseconds to save log messages (default: 10 seconds)
-    /// - max_cache_size:  maximum number of messages stored in this cache (default: 100)        
+    /// - max_cache_size:  maximum number of messages stored in this cache (default: 100)
     /// - index:           ElasticSearch index name (default: "log")
+    /// - indexPattern     Index pattern (default: "yyyyMMdd")
     /// - daily:           true to create a new index every day by adding date suffix to the index name(default: false)
     /// - reconnect:       reconnect timeout in milliseconds(default: 60 sec)
     /// - timeout:         invocation timeout in milliseconds(default: 30 sec)
@@ -69,6 +70,7 @@ namespace PipServices3.ElasticSearch.Log
         private HttpConnectionResolver _connectionResolver = new HttpConnectionResolver();
         private ElasticLowLevelClient _client;
         private string _indexName = "log";
+        private string _indexPattern = "yyyyMMdd";
         private bool _dailyIndex = false;
         private string _currentIndexName;
 
@@ -90,6 +92,7 @@ namespace PipServices3.ElasticSearch.Log
 
             _indexName = config.GetAsStringWithDefault("index", _indexName);
             _dailyIndex = config.GetAsBooleanWithDefault("daily", _dailyIndex);
+            _indexPattern = config.GetAsStringWithDefault ("indexPattern", _indexPattern);
         }
 
         /// <summary>
@@ -169,8 +172,8 @@ namespace PipServices3.ElasticSearch.Log
             if (!_dailyIndex) return _indexName;
 
             var today = DateTime.UtcNow.Date;
-            var dateSuffix = today.ToString("yyyyMMdd");
-            return _indexName + "-" + dateSuffix;  
+            var dateSuffix = today.ToString(_indexPattern);
+            return _indexName + "-" + dateSuffix;
         }
 
         private async Task CreateIndex(string correlationId, bool force)
@@ -297,6 +300,8 @@ namespace PipServices3.ElasticSearch.Log
                 }
                 catch
                 {
+                    // TODO - We need to know when this occurs !!!!!!!!!!!!!!
+
                     // Do nothing if elastic search client was not enable to process bulk of messages
                     _errorConsoleLogger.Error(null, "Failed to bulk messages with Elastic Search Logger.");
                 }

--- a/src/Log/ElasticSearchLogger.cs
+++ b/src/Log/ElasticSearchLogger.cs
@@ -300,8 +300,6 @@ namespace PipServices3.ElasticSearch.Log
                 }
                 catch
                 {
-                    // TODO - We need to know when this occurs !!!!!!!!!!!!!!
-
                     // Do nothing if elastic search client was not enable to process bulk of messages
                     _errorConsoleLogger.Error(null, "Failed to bulk messages with Elastic Search Logger.");
                 }

--- a/test/Log/ElasticSearchLoggerTest.cs
+++ b/test/Log/ElasticSearchLoggerTest.cs
@@ -53,6 +53,7 @@ namespace PipServices3.ElasticSearch.Log
         [Theory]
         [InlineData("yyyyMMdd")]
         [InlineData("yyyy.MM.dd")]
+        [InlineData("yyyy.M.dd")]
         public void TestSimpleLogging(string indexPattern)
         {
             if (_enabled)
@@ -67,6 +68,7 @@ namespace PipServices3.ElasticSearch.Log
         [Theory]
         [InlineData("yyyyMMdd")]
         [InlineData("yyyy.MM.dd")]
+        [InlineData("yyyy.M.dd")]
         public void TestErrorLogging(string indexPattern)
         {
             if (_enabled)

--- a/test/Log/ElasticSearchLoggerTest.cs
+++ b/test/Log/ElasticSearchLoggerTest.cs
@@ -52,7 +52,7 @@ namespace PipServices3.ElasticSearch.Log
 
         [Theory]
         [InlineData("yyyyMMdd")]
-        [InlineData("yyyy.M.dd")]
+        [InlineData("yyyy.MM.dd")]
         public void TestSimpleLogging(string indexPattern)
         {
             if (_enabled)
@@ -66,7 +66,7 @@ namespace PipServices3.ElasticSearch.Log
 
         [Theory]
         [InlineData("yyyyMMdd")]
-        [InlineData("yyyy.M.dd")]
+        [InlineData("yyyy.MM.dd")]
         public void TestErrorLogging(string indexPattern)
         {
             if (_enabled)

--- a/test/Log/ElasticSearchLoggerTest.cs
+++ b/test/Log/ElasticSearchLoggerTest.cs
@@ -12,6 +12,8 @@ namespace PipServices3.ElasticSearch.Log
         private readonly LoggerFixture _fixture;
         private readonly ElasticSearchLoggerFixture _esFixture;
 
+        private string _indexPattern = "yyyyMMdd";
+
         public ElasticSearchLoggerTest()
         {
             var ELASTICSEARCH_ENABLED = Environment.GetEnvironmentVariable("ELASTICSEARCH_ENABLED") ?? "true";
@@ -26,6 +28,7 @@ namespace PipServices3.ElasticSearch.Log
                     "level", "trace",
                     "source", "test",
                     "index", "log",
+                    "indexPattern", _indexPattern,
                     "daily", true,
                     "connection.host", ELASTICSEARCH_SERVICE_HOST,
                     "connection.port", ELASTICSEARCH_SERVICE_PORT
@@ -47,21 +50,29 @@ namespace PipServices3.ElasticSearch.Log
             }
         }
 
-        [Fact]
-        public void TestSimpleLogging()
+        [Theory]
+        [InlineData("yyyyMMdd")]
+        [InlineData("yyyy.M.dd")]
+        public void TestSimpleLogging(string indexPattern)
         {
             if (_enabled)
             {
+                _indexPattern = indexPattern;
+
                 _fixture.TestSimpleLogging();
                 _esFixture.TestSimpleLogging();
             }
         }
 
-        [Fact]
-        public void TestErrorLogging()
+        [Theory]
+        [InlineData("yyyyMMdd")]
+        [InlineData("yyyy.M.dd")]
+        public void TestErrorLogging(string indexPattern)
         {
             if (_enabled)
             {
+                _indexPattern = indexPattern;
+
                 _fixture.TestErrorLogging();
                 _esFixture.TestErrorLogging();
             }


### PR DESCRIPTION
We need a configurable index pattern for elastic search.

I have updated the code to get the index pattern from the config file or default it to `yyyyMMdd`
I have added tests for this change.