### PR TITLE
New Options Added From The Node Version

### DIFF
--- a/src/Log/ElasticSearchLogger.cs
+++ b/src/Log/ElasticSearchLogger.cs
@@ -38,7 +38,7 @@ namespace PipServices3.ElasticSearch.Log
     /// - interval:        interval in milliseconds to save log messages (default: 10 seconds)
     /// - max_cache_size:  maximum number of messages stored in this cache (default: 100)
     /// - index:           ElasticSearch index name (default: "log")
-    /// - date_format      The date format to use when creating the index name. Eg. log-yyyyMMdd (default: "yyyyMMdd"). See [[https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings]]
+    /// - date_format      The date format to use when creating the index name. Eg. log-yyyyMMdd (default: "yyyyMMdd"). See [[https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings]]
     /// - daily:           true to create a new index every day by adding date suffix to the index name(default: false)
     /// - reconnect:       reconnect timeout in milliseconds(default: 60 sec)
     /// - timeout:         invocation timeout in milliseconds(default: 30 sec)

--- a/test/Log/ElasticSearchLoggerTest.cs
+++ b/test/Log/ElasticSearchLoggerTest.cs
@@ -12,7 +12,7 @@ namespace PipServices3.ElasticSearch.Log
         private readonly LoggerFixture _fixture;
         private readonly ElasticSearchLoggerFixture _esFixture;
 
-        private string _indexPattern = "yyyyMMdd";
+        private string _dateFormat = "yyyyMMdd";
 
         public ElasticSearchLoggerTest()
         {
@@ -21,6 +21,7 @@ namespace PipServices3.ElasticSearch.Log
             var ELASTICSEARCH_SERVICE_PORT = Environment.GetEnvironmentVariable("ELASTICSEARCH_SERVICE_PORT") ?? "9200";
 
             _enabled = BooleanConverter.ToBoolean(ELASTICSEARCH_ENABLED);
+
             if (_enabled)
             {
                 _logger = new TestElasticSearchLogger();
@@ -28,7 +29,7 @@ namespace PipServices3.ElasticSearch.Log
                     "level", "trace",
                     "source", "test",
                     "index", "log",
-                    "indexPattern", _indexPattern,
+                    "date_format", _dateFormat,
                     "daily", true,
                     "connection.host", ELASTICSEARCH_SERVICE_HOST,
                     "connection.port", ELASTICSEARCH_SERVICE_PORT
@@ -38,7 +39,7 @@ namespace PipServices3.ElasticSearch.Log
                 _esFixture = new ElasticSearchLoggerFixture(_logger);
 
                 _logger.OpenAsync(null).Wait();
-                _logger.OpenAsync(null).Wait();
+                // _logger.OpenAsync(null).Wait();
             }
         }
 
@@ -54,11 +55,11 @@ namespace PipServices3.ElasticSearch.Log
         [InlineData("yyyyMMdd")]
         [InlineData("yyyy.MM.dd")]
         [InlineData("yyyy.M.dd")]
-        public void TestSimpleLogging(string indexPattern)
+        public void TestSimpleLogging(string dateFormat)
         {
             if (_enabled)
             {
-                _indexPattern = indexPattern;
+                _dateFormat = dateFormat;
 
                 _fixture.TestSimpleLogging();
                 _esFixture.TestSimpleLogging();
@@ -69,11 +70,11 @@ namespace PipServices3.ElasticSearch.Log
         [InlineData("yyyyMMdd")]
         [InlineData("yyyy.MM.dd")]
         [InlineData("yyyy.M.dd")]
-        public void TestErrorLogging(string indexPattern)
+        public void TestErrorLogging(string dateFormat)
         {
             if (_enabled)
             {
-                _indexPattern = indexPattern;
+                _dateFormat = dateFormat;
 
                 _fixture.TestErrorLogging();
                 _esFixture.TestErrorLogging();


### PR DESCRIPTION
**New Options Added From The Node Version**

Added the parameters to the elasticsearch low level client

- `reconnect`
- `timeout`
- `max_retries`

Added the parameter `index_message` to the creation of the index.

This matches the functionality that exists in the node version of the package.

**Renaming options parameter to match current framework conventions**

Updated the the option `indexPattern` to `date_format` to both match the node version and the current naming convention in the framework.